### PR TITLE
add better error handling to maybe fix home assistant crashing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# Check http://editorconfig.org for more information
+# This is the main config file for this project:
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.{bat,cmd}]
+end_of_line = crlf

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@v1.1.51
         with:
-          github-token: ${{ secrets.ACTION_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pytest-xml-coverage-path: ./test_results/cov_xml/coverage.xml
           junitxml-path: ./test_results/pytest.xml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,8 +2,8 @@ name: "Validate"
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  "0 0 * * *"
+  # schedule:
+  #   - cron:  "0 0 * * *"
   push:
     branches:
       - "main"

--- a/custom_components/combustion/sensor.py
+++ b/custom_components/combustion/sensor.py
@@ -154,7 +154,11 @@ class CombustionRSSISensor(CombustionEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
-        return self.probe_manager.probe_data(self.device_serial_number).rssi
+        try:
+            return self.probe_manager.probe_data(self.device_serial_number).rssi
+        except Exception as ex:
+            _LOGGER.warning("Error getting rssi for native_value: %s", ex)
+            return "Unknown"
 
 class BaseCombustionTemperatureSensor(CombustionEntity, SensorEntity):
     """Base class for temperature sensors."""
@@ -188,7 +192,7 @@ class BaseCombustionTemperatureSensor(CombustionEntity, SensorEntity):
         try:
             raw_bytes = self.probe_manager.probe_data(self.device_serial_number).advertising_data.bit_string
         except Exception as ex:
-            _LOGGER.warn("Error getting raw bitstring for extra_state_attributes: %s", ex)
+            _LOGGER.warning("Error getting raw bitstring for extra_state_attributes: %s", ex)
             return {}
 
         return {
@@ -232,15 +236,24 @@ class CombustionVirtualCoreSensor(BaseCombustionTemperatureSensor):
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
-        (id, temp) = self.probe_manager.probe_data(self.device_serial_number).core_sensor
+        try:
+            (_thermistor_id, temp) = self.probe_manager.probe_data(self.device_serial_number).core_sensor
+        except Exception as ex:
+            _LOGGER.warning("Error getting core_sensor temp for native_value: %s", ex)
+            return "Unknown"
         return temp
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """State attributes."""
-        (id, temp) = self.probe_manager.probe_data(self.device_serial_number).core_sensor
+        try:
+            (thermistor_id, _temp) = self.probe_manager.probe_data(self.device_serial_number).core_sensor
+        except Exception as ex:
+            _LOGGER.warning("Error getting core_sensor id for extra_state_attributes: %s", ex)
+            return {}
+
         return {
-            "thermistor_id": id
+            "thermistor_id": thermistor_id
         }
 
 class CombustionVirtualAmbientSensor(BaseCombustionTemperatureSensor):
@@ -260,15 +273,25 @@ class CombustionVirtualAmbientSensor(BaseCombustionTemperatureSensor):
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
-        (id, temp) = self.probe_manager.probe_data(self.device_serial_number).ambient_sensor
+        try:
+            (_thermistor_id, temp) = self.probe_manager.probe_data(self.device_serial_number).ambient_sensor
+        except Exception as ex:
+            _LOGGER.warning("Error getting ambient_sensor temp for extra_state_attributes: %s", ex)
+            return "Unknown"
+
         return temp
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """State attributes."""
-        (id, temp) = self.probe_manager.probe_data(self.device_serial_number).ambient_sensor
+        try:
+            (thermistor_id, _temp) = self.probe_manager.probe_data(self.device_serial_number).ambient_sensor
+        except Exception as ex:
+            _LOGGER.warning("Error getting ambient_sensor id for extra_state_attributes: %s", ex)
+            return {}
+
         return {
-            "thermistor_id": id
+            "thermistor_id": thermistor_id
         }
 
 class CombustionVirtualSurfaceSensor(BaseCombustionTemperatureSensor):
@@ -288,13 +311,23 @@ class CombustionVirtualSurfaceSensor(BaseCombustionTemperatureSensor):
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
-        (id, temp) = self.probe_manager.probe_data(self.device_serial_number).surface_sensor
+        try:
+            (_thermistor_id, temp) = self.probe_manager.probe_data(self.device_serial_number).surface_sensor
+        except Exception as ex:
+            _LOGGER.warning("Error getting surface_sensor temp for native_value: %s", ex)
+            return "Unknown"
+
         return temp
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """State attributes."""
-        (id, temp) = self.probe_manager.probe_data(self.device_serial_number).surface_sensor
+        try:
+            (thermistor_id, _temp) = self.probe_manager.probe_data(self.device_serial_number).surface_sensor
+        except Exception as ex:
+            _LOGGER.warning("Error getting surface_sensor id for extra_state_attributes: %s", ex)
+            return {}
+
         return {
-            "thermistor_id": id
+            "thermistor_id": thermistor_id
         }


### PR DESCRIPTION
add better error handling to maybe fix home assistant crashing

use built in github token for pytest comment action

add editorconfig file that will give VSCode, GitHub webui, and other code editors hints on formatting.

This MIGHT resolve this issue: https://github.com/legrego/homeassistant-combustion/issues/68