### PR TITLE
Remove bitstring requirement to fix installation on HA 2026.3+ (Python 3.14)

### DIFF
--- a/custom_components/combustion/combustion_ble/advertising_data.py
+++ b/custom_components/combustion/combustion_ble/advertising_data.py
@@ -33,8 +33,6 @@ class AdvertisingData(NamedTuple):
     @staticmethod
     def from_data(data: bytes) -> Optional['AdvertisingData']:
         """Create instance from raw advertising data."""
-        from bitstring import Bits
-
         if data is None or len(data) < 20:
             LOGGER.warn('Not constructing Advertising data because [%s] != 20', len(data))
             return None
@@ -65,6 +63,6 @@ class AdvertisingData(NamedTuple):
         hop_count = HopCount.from_network_info_byte(data[22]) if len(data) >= 23 else HopCount.default_values()
 
         # Bit String
-        bit_string = Bits(data).bin
+        bit_string = ''.join(format(byte, '08b') for byte in data)
 
         return AdvertisingData(type=product_type, serial_number=serial_number, temperatures=temperatures, mode_id=mode_id, battery_status_virtual_sensors=battery_status_virtual_sensors, hop_count=hop_count, bit_string=bit_string)

--- a/custom_components/combustion/manifest.json
+++ b/custom_components/combustion/manifest.json
@@ -17,8 +17,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/legrego/homeassistant-combustion/issues",
-  "requirements": [
-    "bitstring==4.1.4"
-  ],
+  "requirements": [],
   "version": "0.0.0"
 }


### PR DESCRIPTION
Closes #108.

## Problem

Home Assistant 2026.x runs Python 3.14. This integration pins `bitstring==4.1.4`, which depends on `bitarray>=2.8,<3.0` — a C extension whose final 2.x release (Oct 2024) ships wheels for CPython 3.11–3.13 only. On Python 3.14 there is no wheel and pip inside the HA container can't build from source, so requirement installation fails and the integration never loads:

```
homeassistant.requirements.RequirementsNotFound: Requirements for combustion not found: ['bitstring==4.1.4']
```

## Fix

`bitstring` has exactly one runtime call site: `Bits(data).bin` in `AdvertisingData.from_data`, producing the binary string used for the `raw_advertisement_bytes` debug attribute. This PR replaces it with the equivalent pure-Python expression and removes the requirement:

```python
bit_string = ''.join(format(byte, '08b') for byte in data)
```

I verified the replacement is byte-for-byte identical to `Bits(data).bin` across 1000 randomized 20–23 byte payloads, and against live advertisements from a Predictive Thermometer (gen 2) and a Booster.

`bitstring` remains available to the test suite (`tests/utils/bt_utils.py`) via the poetry dev environment — this PR only removes the runtime requirement that ships to Home Assistant, so no test changes are needed.

## Alternatives considered

- **Bump the pin to `bitstring>=4.3`** (bitarray 3.x has 3.14 wheels): smallest textual diff, but keeps a C-extension dependency for one debug string, upgrades the library under all existing users, and recurs at the next Python bump until wheels appear.
- **Environment-marker split** (`bitstring==4.1.4;python_version<'3.14'` + a newer pin above): most conservative for existing installs, but the added complexity buys nothing — both versions produce identical output for this call.

Removing the dependency seemed like the option you'd never have to think about again.

## Testing

- `poetry run pytest` — 3/3 pass (the existing tests exercise `AdvertisingData.from_data` end-to-end via the injected BLE advertisement).
- Running in production on HA OS 2026.3 (amd64, HAOS 17.1) since 2026-07-13 without issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
