### PR TITLE
Match non-connectable advertisements from passive bluetooth proxies (e.g. Shelly)

### DIFF
--- a/custom_components/combustion/bluetooth_listener.py
+++ b/custom_components/combustion/bluetooth_listener.py
@@ -31,7 +31,13 @@ class BluetoothListener:
             bluetooth.async_register_callback(
                 self.hass,
                 self._bt_callback,
-                bluetooth.BluetoothCallbackMatcher(manufacturer_id=BT_MANUFACTURER_ID),
+                # connectable=False means "a connection is not required":
+                # it matches BOTH connectable and non-connectable sources.
+                # The default (True) silently drops advertisements relayed by
+                # passive bluetooth proxies such as Shelly devices, which
+                # always report connectable=False. This integration only
+                # reads advertisement broadcasts and never connects.
+                bluetooth.BluetoothCallbackMatcher(manufacturer_id=BT_MANUFACTURER_ID, connectable=False),
                 bluetooth.BluetoothScanningMode.ACTIVE
             )
         )

--- a/custom_components/combustion/manifest.json
+++ b/custom_components/combustion/manifest.json
@@ -3,7 +3,8 @@
   "name": "Combustion",
   "bluetooth": [
     {
-      "manufacturer_id": 2503
+      "manufacturer_id": 2503,
+      "connectable": false
     }
   ],
   "codeowners": [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -57,3 +57,32 @@ async def test_entity_creation(hass: HomeAssistant):
     # 9 disabled by default: 8 temperature sensors, and 1 RSSI sensor
     assert len(disabled_sensors) == 9
     assert len(binary_sensors) == 1
+
+
+@pytest.mark.asyncio
+async def test_entity_creation_non_connectable(hass: HomeAssistant):
+    """Advertisements relayed by passive bluetooth proxies must be processed.
+
+    Passive proxies (e.g. Shelly devices) deliver advertisements with
+    connectable=False; a callback matcher without connectable=False never
+    sees them, so probes are silently ignored on proxy-only installations.
+    """
+
+    mock_entry = MockConfigEntry(
+        unique_id="test_entity_creation_non_connectable",
+        domain=DOMAIN,
+        version=1,
+        data={
+        },
+        title="Meatnet",
+    )
+
+    entry = await _setup_config_entry(hass, mock_entry)
+
+    er = entity_registry.async_get(hass)
+
+    inject_bt_advertisement(hass, create_advertisement(create_combustion_bits(), connectable=False))
+    await hass.async_block_till_done()
+
+    entities = entity_registry.async_entries_for_config_entry(er, entry.entry_id)
+    assert len(entities) == 13

--- a/tests/utils/bt_utils.py
+++ b/tests/utils/bt_utils.py
@@ -90,7 +90,7 @@ def inject_bt_advertisement(hass: HomeAssistant, service_info: BluetoothServiceI
     """Inject a BT advertisement into HASS."""
     async_get_advertisement_callback(hass)(service_info)
 
-def create_advertisement(combustion_bits):
+def create_advertisement(combustion_bits, connectable=True):
     """Create a BT advertisement."""
     adv = generate_advertisement_data(
         manufacturer_data={2503: combustion_bits},
@@ -114,7 +114,7 @@ def create_advertisement(combustion_bits):
         ],
         source='B8:27:EB:EA:98:17',
         advertisement=adv,
-        connectable=True,
+        connectable=connectable,
         time=0,
     )
 


### PR DESCRIPTION
Closes #113.

## Problem

On installations whose only Bluetooth coverage comes from **passive proxies** — most commonly Shelly devices acting as BLE relays — this integration never detects any probe, with nothing in the logs to explain why. The advertisements arrive in Home Assistant (visible in the bluetooth advertisement monitor), but the integration's callback never fires.

## Root cause

Home Assistant's bluetooth callback matchers default to `connectable=True`, and `ble_device_matches` rejects any advertisement whose source can't accept connections ([`homeassistant/components/bluetooth/match.py`](https://github.com/home-assistant/core/blob/2026.3.0/homeassistant/components/bluetooth/match.py#L409)):

```python
if matcher.get(CONNECTABLE, True) and not service_info.connectable:
    return False
```

Passive proxies always deliver advertisements with `connectable=False` (they can relay broadcasts but cannot proxy GATT connections — unlike ESPHome proxies in active mode). The integration's matcher — `BluetoothCallbackMatcher(manufacturer_id=2503)` — therefore silently drops every one of them. I confirmed this live: HA's advertisement stream showed the probe's complete, valid manufacturer payload arriving via a Shelly proxy with `connectable: false`, while the integration received nothing.

## Fix

Declare `connectable=False` in the runtime callback matcher and the manifest's discovery matcher. In matcher semantics this means "a connection is not required", **not** "only non-connectable" — it matches both connectable and non-connectable sources, so local adapters and active ESPHome proxies behave exactly as before. It's also the semantically correct declaration for this integration, which only reads advertisement broadcasts and never opens a GATT connection.

## Tests

`test_entity_creation_non_connectable` injects a non-connectable advertisement (as a passive proxy would deliver) and asserts the usual 13 entities are created. Verified red/green: it fails on `main` without the matcher change and passes with it. `poetry run pytest`: 4/4.

Running in production since 2026-07-13 on an installation with four Shelly BLE proxies and no other Bluetooth coverage — probe detection went from zero advertisements to fully working with this change alone.

Independent of #110 and #111, though a proxy-only installation on current HA needs all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
